### PR TITLE
chore: pin gatsby-plugin-manifest to 2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gatsby": "^2.0.29",
     "gatsby-image": "^2.0.10",
     "gatsby-plugin-google-analytics": "^2.0.0-beta.3",
-    "gatsby-plugin-manifest": "^2.0.3",
+    "gatsby-plugin-manifest": "2.0.5",
     "gatsby-plugin-offline": "^2.0.0-beta.9",
     "gatsby-plugin-react-helmet": "^3.0.0-beta.4",
     "gatsby-plugin-sentry": "^0.1.0",


### PR DESCRIPTION
Resolves #89.